### PR TITLE
feat(version-control): add Git-based document history access

### DIFF
--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -74,7 +74,7 @@ ChronDB also provides low-level access to Git-based document history, allowing y
 
 ### Retrieving Specific Document Versions
 
-You can retrieve a document at a specific commit by providing the commit hash:
+You can retrieve a document at a specific commit by providing the commit hash. Note that each retrieval operation generates a new commit to maintain chronological integrity:
 
 ```clojure
 ;; Get a document at a specific commit

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -49,6 +49,41 @@ ChronDB provides API methods to access the complete history of any document:
 ;; ]
 ```
 
+ChronDB also provides low-level access to Git-based document history, allowing you to retrieve detailed commit information and document content at each version:
+
+```clojure
+;; Get detailed document history with Git commit metadata
+(def git-history (chrondb/get-document-history db "user:1"))
+
+;; Example git-history result
+;; [
+;;   {:commit-id "8f7e6d5c4b3a2...",
+;;    :commit-time #inst "2023-05-15T09:45:00Z",
+;;    :commit-message "Save document",
+;;    :committer-name "ChronDB",
+;;    :committer-email "system@chrondb.com",
+;;    :document {:name "John", :email "john.doe@example.com"}}
+;;   {:commit-id "1a2b3c4d5e6f7...",
+;;    :commit-time #inst "2023-05-10T14:30:00Z",
+;;    :commit-message "Save document",
+;;    :committer-name "ChronDB",
+;;    :committer-email "system@chrondb.com",
+;;    :document {:name "John", :email "john@example.com"}}
+;; ]
+```
+
+### Retrieving Specific Document Versions
+
+You can retrieve a document at a specific commit by providing the commit hash:
+
+```clojure
+;; Get a document at a specific commit
+(def old-version (chrondb/get-document-at-commit db-repository "user:1" "1a2b3c4d5e6f7..."))
+
+;; Example result
+;; {:name "John", :email "john@example.com"}
+```
+
 Through other protocols, document history is also accessible:
 
 **REST API:**
@@ -311,11 +346,24 @@ ChronDB makes it easy to revert to previous states:
 (chrondb/revert-all db "2023-05-10T14:30:00Z")
 ```
 
+For git-based storage, you can also restore a document to a specific version by commit hash while preserving the complete history:
+
+```clojure
+;; Restore a document to a specific version by commit hash
+(def restored-doc (chrondb/restore-document-version db "user:1" "1a2b3c4d5e6f7..."))
+
+;; This creates a new commit that reverts the document to that version,
+;; while preserving the complete history of changes
+```
+
+Unlike a traditional rollback that might discard history, this approach adds a new restoration commit that preserves the complete chronology of changes, ensuring full audit trails are maintained.
+
 This enables:
 
 - Recovering from errors
 - Undoing problematic changes
 - Testing with real data then reverting
+- Maintaining a complete audit trail of all operations
 
 ## Performance Considerations
 

--- a/src/chrondb/index/lucene.clj
+++ b/src/chrondb/index/lucene.clj
@@ -9,8 +9,7 @@
            [org.apache.lucene.index IndexWriter IndexWriterConfig IndexWriterConfig$OpenMode DirectoryReader Term IndexNotFoundException]
            [org.apache.lucene.search IndexSearcher Query ScoreDoc TopDocs]
            [org.apache.lucene.queryparser.classic QueryParser ParseException]
-           [java.nio.file Paths]
-           [java.io Closeable]))
+           [java.nio.file Paths]))
 
 (defn- create-lucene-doc
   "Creates a Lucene Document from a Clojure map, using different analyzers."
@@ -151,7 +150,6 @@
         (log/log-error (str "Unexpected error trying to search the index: " (.getMessage e)))
         [])))
 
-  Closeable
   (close [_]
     (log/log-info "Closing Lucene index...")
     (try (.close writer) (catch Exception e (log/log-error (str "Error closing IndexWriter: " (.getMessage e)))))

--- a/src/chrondb/index/memory.clj
+++ b/src/chrondb/index/memory.clj
@@ -41,7 +41,12 @@
                      (= field "content") (str/includes? (str/lower-case v) query-lower)
                      :else false)))
                doc))
-       all-docs))))
+       all-docs)))
+
+  (close [_]
+    (log/log-info "Closing MemoryIndex...")
+    (.clear data)
+    (log/log-info "MemoryIndex closed.")))
 
 (defn create-memory-index
   "Creates a new in-memory index.

--- a/src/chrondb/storage/git.clj
+++ b/src/chrondb/storage/git.clj
@@ -576,6 +576,17 @@
   [storage id & [branch]]
   (protocol/get-document-history storage id branch))
 
+;; Add this private helper function
+(defn- normalize-commit-hash
+  "Normalize a commit hash string to extract just the hash part."
+  [commit-hash]
+  (if (string? commit-hash)
+    ;; If it contains spaces, it might be in format "commit HASH ..."
+    (if (.contains commit-hash " ")
+      (second (clojure.string/split commit-hash #" "))
+      commit-hash)
+    (str commit-hash)))
+
 (defn get-document-at-commit
   "Get the document content at a specific commit hash."
   [repository id commit-hash]
@@ -584,13 +595,7 @@
           doc-path (get-document-path repository id)]
       (when doc-path
         (try
-          ;; Process commit-hash to extract just the hash part if needed
-          (let [clean-hash (if (string? commit-hash)
-                             ;; If it contains spaces, it might be in format "commit HASH ..."
-                             (if (.contains commit-hash " ")
-                               (second (clojure.string/split commit-hash #" "))
-                               commit-hash)
-                             (str commit-hash))
+          (let [clean-hash (normalize-commit-hash commit-hash)
                 _ (log/log-info (str "Using commit hash: " clean-hash))
                 commit-id (try
                             (ObjectId/fromString clean-hash)

--- a/src/chrondb/storage/git.clj
+++ b/src/chrondb/storage/git.clj
@@ -13,10 +13,11 @@
            [org.eclipse.jgit.dircache DirCache DirCacheEntry]
            [org.eclipse.jgit.lib ConfigConstants Constants ObjectId]
            [org.eclipse.jgit.lib CommitBuilder FileMode RefUpdate$Result]
-           [org.eclipse.jgit.revwalk RevWalk]
+           [org.eclipse.jgit.revwalk RevCommit RevWalk]
            [org.eclipse.jgit.transport RefSpec]
            [org.eclipse.jgit.treewalk CanonicalTreeParser TreeWalk]
-           [org.eclipse.jgit.util SystemReader]))
+           [org.eclipse.jgit.util SystemReader]
+           [org.eclipse.jgit.treewalk.filter PathFilter]))
 
 (defn ensure-directory
   "Creates a directory if it doesn't exist.
@@ -270,6 +271,64 @@
               (.close tree-walk)
               (.close rev-walk))))))))
 
+(defn- fetch-document-history
+  "Internal helper function to get the history of changes for a document.
+   Returns a sequence of maps containing commit info and document content at each version.
+   Similar to `git log -p -- file` command."
+  [repository id branch]
+  (let [config-map (config/load-config)
+        branch-name (or branch (get-in config-map [:git :default-branch]))
+        doc-path (get-document-path repository id branch-name)]
+
+    (when (and repository doc-path)
+      (let [git (Git/wrap repository)
+            rev-walk (RevWalk. repository)
+            log-command (-> git
+                            (.log)
+                            (.addPath doc-path))]
+
+        (try
+          (let [commits (iterator-seq (.iterator (.call log-command)))
+                results (atom [])]
+
+            (doseq [commit commits]
+              (let [commit-id (.getId commit)
+                    tree-walk (TreeWalk. repository)
+                    tree-id (.getTree commit)
+                    commit-time (Date. (* 1000 (.getCommitTime commit)))
+                    commit-message (.getFullMessage commit)
+                    committer (.getCommitterIdent commit)
+                    committer-name (.getName committer)
+                    committer-email (.getEmailAddress committer)]
+
+                ;; Get document content at this revision
+                (.addTree tree-walk (.parseTree rev-walk tree-id))
+                (.setRecursive tree-walk true)
+                (.setFilter tree-walk (PathFilter/create doc-path))
+
+                (when (.next tree-walk)
+                  (let [object-id (.getObjectId tree-walk 0)
+                        object-loader (.open repository object-id)
+                        content (String. (.getBytes object-loader) "UTF-8")
+                        doc-content (try
+                                      (json/read-str content :key-fn keyword)
+                                      (catch Exception e
+                                        {:error (str "Failed to parse document: " (.getMessage e))
+                                         :raw-content content}))]
+
+                    (swap! results conj {:commit-id (str commit-id)
+                                         :commit-time commit-time
+                                         :commit-message commit-message
+                                         :committer-name committer-name
+                                         :committer-email committer-email
+                                         :document doc-content})))
+
+                (.close tree-walk)))
+
+            @results)
+          (finally
+            (.close rev-walk)))))))
+
 (defrecord GitStorage [repository data-dir]
   protocol/Storage
   (save-document [_ document]
@@ -368,7 +427,7 @@
                       content (String. (.getBytes object-loader) "UTF-8")
                       doc (json/read-str content :key-fn keyword)]
                   (if (or (empty? encoded-prefix)
-                           ;; If we have a prefix, check if the path contains it
+                          ;; If we have a prefix, check if the path contains it
                           (.contains path encoded-prefix))
                     (do
                       (log/log-info (str "Document matched prefix: " (:id doc)))
@@ -480,6 +539,15 @@
         ;; Document not found, return false
         false)))
 
+  (get-document-history [_ id]
+    (protocol/get-document-history _ id nil))
+
+  (get-document-history [_ id branch]
+    (when-not repository
+      (throw (Exception. "Repository is closed")))
+
+    (fetch-document-history repository id branch))
+
   (close [_]
     (when repository
       (.close repository)
@@ -495,3 +563,95 @@
      (create-git-storage path (get-in config-map [:storage :data-dir]))))
   ([path data-dir]
    (->GitStorage (create-repository path) data-dir)))
+
+(defn get-document-history
+  "Get the history of changes for a document.
+   Returns a sequence of maps containing commit info and document content at each version.
+   Similar to `git log -p -- file` command.
+
+   Parameters:
+   storage - The GitStorage instance
+   id - Document ID
+   branch - Optional branch name (defaults to the configured default branch)"
+  [storage id & [branch]]
+  (protocol/get-document-history storage id branch))
+
+(defn get-document-at-commit
+  "Get the document content at a specific commit hash."
+  [repository id commit-hash]
+  (when (and repository commit-hash id)
+    (let [git (Git/wrap repository)
+          rev-walk (RevWalk. repository)
+          doc-path (get-document-path repository id)]
+      (when doc-path
+        (try
+          ;; Process commit-hash to extract just the hash part if needed
+          (let [clean-hash (if (string? commit-hash)
+                             ;; If it contains spaces, it might be in format "commit HASH ..."
+                             (if (.contains commit-hash " ")
+                               (second (clojure.string/split commit-hash #" "))
+                               commit-hash)
+                             (str commit-hash))
+                _ (log/log-info (str "Using commit hash: " clean-hash))
+                commit-id (try
+                            (ObjectId/fromString clean-hash)
+                            (catch Exception e
+                              (log/log-warn "Invalid commit hash format:" clean-hash)
+                              nil))]
+            (when commit-id
+              (let [commit (.parseCommit rev-walk commit-id)
+                    tree-walk (TreeWalk. repository)]
+                (try
+                  (.addTree tree-walk (.parseTree rev-walk (.getTree commit)))
+                  (.setRecursive tree-walk true)
+                  (.setFilter tree-walk (PathFilter/create doc-path))
+
+                  (when (.next tree-walk)
+                    (let [object-id (.getObjectId tree-walk 0)
+                          object-loader (.open repository object-id)
+                          content (String. (.getBytes object-loader) "UTF-8")]
+                      (try
+                        (json/read-str content :key-fn keyword)
+                        (catch Exception e
+                          (log/log-warn "Failed to parse document:" (.getMessage e))
+                          nil))))
+                  (finally
+                    (.close tree-walk))))))
+          (catch Exception e
+            (log/log-warn "Error getting document at commit:" (.getMessage e))
+            nil)
+          (finally
+            (.close rev-walk)))))))
+
+(defn restore-document-version
+  "Restore a document to a specific version by creating a new commit."
+  [storage id commit-hash & [branch]]
+  (let [repository (:repository storage)
+        config-map (config/load-config)
+        branch-name (or branch (get-in config-map [:git :default-branch]))]
+
+    (when-not repository
+      (throw (Exception. "Repository is closed")))
+
+    ;; Process commit-hash to extract just the hash part if needed
+    (let [clean-hash (if (string? commit-hash)
+                       ;; If it contains spaces, it might be in format "commit HASH ..."
+                       (if (.contains commit-hash " ")
+                         (second (clojure.string/split commit-hash #" "))
+                         commit-hash)
+                       (str commit-hash))
+          _ (log/log-info (str "Using commit hash for restore: " clean-hash))
+          doc (get-document-at-commit repository id clean-hash)]
+      (if doc
+        (let [message (str "Restore document " id " to version " clean-hash)]
+          (commit-virtual (Git/wrap repository)
+                          branch-name
+                          (get-file-path (:data-dir storage) id (:_table doc))
+                          (json/write-str doc)
+                          message
+                          (get-in config-map [:git :committer-name])
+                          (get-in config-map [:git :committer-email]))
+
+          (push-changes (Git/wrap repository) config-map)
+          doc)
+        (throw (ex-info "Document version not found" {:id id :commit-hash clean-hash}))))))

--- a/src/chrondb/storage/git.clj
+++ b/src/chrondb/storage/git.clj
@@ -638,12 +638,7 @@
       (throw (Exception. "Repository is closed")))
 
     ;; Process commit-hash to extract just the hash part if needed
-    (let [clean-hash (if (string? commit-hash)
-                       ;; If it contains spaces, it might be in format "commit HASH ..."
-                       (if (.contains commit-hash " ")
-                         (second (clojure.string/split commit-hash #" "))
-                         commit-hash)
-                       (str commit-hash))
+    (let [clean-hash (normalize-commit-hash commit-hash)
           _ (log/log-info (str "Using commit hash for restore: " clean-hash))
           doc (get-document-at-commit repository id clean-hash)]
       (if doc

--- a/src/chrondb/storage/git.clj
+++ b/src/chrondb/storage/git.clj
@@ -13,7 +13,7 @@
            [org.eclipse.jgit.dircache DirCache DirCacheEntry]
            [org.eclipse.jgit.lib ConfigConstants Constants ObjectId]
            [org.eclipse.jgit.lib CommitBuilder FileMode RefUpdate$Result]
-           [org.eclipse.jgit.revwalk RevCommit RevWalk]
+           [org.eclipse.jgit.revwalk RevWalk]
            [org.eclipse.jgit.transport RefSpec]
            [org.eclipse.jgit.treewalk CanonicalTreeParser TreeWalk]
            [org.eclipse.jgit.util SystemReader]
@@ -580,8 +580,7 @@
   "Get the document content at a specific commit hash."
   [repository id commit-hash]
   (when (and repository commit-hash id)
-    (let [git (Git/wrap repository)
-          rev-walk (RevWalk. repository)
+    (let [rev-walk (RevWalk. repository)
           doc-path (get-document-path repository id)]
       (when doc-path
         (try
@@ -595,7 +594,7 @@
                 _ (log/log-info (str "Using commit hash: " clean-hash))
                 commit-id (try
                             (ObjectId/fromString clean-hash)
-                            (catch Exception e
+                            (catch Exception _
                               (log/log-warn "Invalid commit hash format:" clean-hash)
                               nil))]
             (when commit-id

--- a/src/chrondb/storage/memory.clj
+++ b/src/chrondb/storage/memory.clj
@@ -44,6 +44,18 @@
   [^ConcurrentHashMap data]
   (.clear data))
 
+(defn get-document-history-memory
+  "Simulates document history for in-memory storage.
+   Since memory storage doesn't track history, this returns just the current state."
+  [^ConcurrentHashMap data id]
+  (when-let [doc (get-document-memory data id)]
+    [{:commit-id "memory-current"
+      :commit-time (java.util.Date.)
+      :commit-message "Current version"
+      :committer-name "Memory Storage"
+      :committer-email "memory@chrondb.com"
+      :document doc}]))
+
 (defrecord MemoryStorage [^ConcurrentHashMap data]
   protocol/Storage
   (save-document [_ doc] (save-document-memory data doc))
@@ -60,6 +72,9 @@
 
   (get-documents-by-table [_ table-name] (get-documents-by-table-memory data table-name))
   (get-documents-by-table [_ table-name _branch] (get-documents-by-table-memory data table-name))
+
+  (get-document-history [_ id] (get-document-history-memory data id))
+  (get-document-history [_ id _branch] (get-document-history-memory data id))
 
   (close [_]
     (close-memory-storage data)

--- a/src/chrondb/storage/protocol.clj
+++ b/src/chrondb/storage/protocol.clj
@@ -52,6 +52,15 @@
      - branch: (Optional) The branch name to get documents from (default branch if nil)
      Returns: A sequence of documents for the table.")
 
+  (get-document-history
+    [this id]
+    [this id branch]
+    "Retrieves the history of a document by its ID.
+     Parameters:
+     - id: The unique identifier of the document
+     - branch: (Optional) The branch name to get the document history from (default branch if nil)
+     Returns: A sequence of maps containing commit info and document content at each version.")
+
   (close [this]
     "Closes the storage system and releases any resources.
      Should be called when the storage system is no longer needed.

--- a/test/chrondb/api/sql/execution/query_test.clj
+++ b/test/chrondb/api/sql/execution/query_test.clj
@@ -52,6 +52,24 @@
              (map second)
              (into [])))
 
+      (get-document-history [_ id]
+        (when-let [doc (get @documents id)]
+          [{:commit-id "mock-current"
+            :commit-time (java.util.Date.)
+            :commit-message "Current version"
+            :committer-name "Mock Storage"
+            :committer-email "mock@chrondb.com"
+            :document doc}]))
+
+      (get-document-history [_ id _branch]
+        (when-let [doc (get @documents id)]
+          [{:commit-id "mock-current"
+            :commit-time (java.util.Date.)
+            :commit-message "Current version"
+            :committer-name "Mock Storage"
+            :committer-email "mock@chrondb.com"
+            :document doc}]))
+
       (save-document [_ doc]
         (swap! documents assoc (:id doc) doc)
         doc)

--- a/test/chrondb/storage/git_test.clj
+++ b/test/chrondb/storage/git_test.clj
@@ -235,3 +235,157 @@
         (is (= doc (protocol/get-document storage (:id doc)))))
 
       (protocol/close storage))))
+
+(deftest test-document-history
+  (testing "Document history retrieval"
+    (let [storage (git/create-git-storage test-repo-path)
+          doc-v1 {:id "history-test:1" :name "Original" :value 1 :_table "history"}
+          doc-v2 {:id "history-test:1" :name "Updated" :value 2 :_table "history"}
+          doc-v3 {:id "history-test:1" :name "Final" :value 3 :_table "history"}]
+
+      ;; Create document with multiple versions
+      (protocol/save-document storage doc-v1)
+      (protocol/save-document storage doc-v2)
+      (protocol/save-document storage doc-v3)
+
+      ;; Get document history
+      (let [history (protocol/get-document-history storage "history-test:1")]
+        (is (= 3 (count history)) "Should have 3 versions in history")
+
+        ;; Check that most recent version comes first
+        (is (= 3 (get-in history [0 :document :value])) "Most recent version should be first")
+        (is (= 2 (get-in history [1 :document :value])) "Second version should be second")
+        (is (= 1 (get-in history [2 :document :value])) "Original version should be last")
+
+        ;; Verify commit metadata exists
+        (is (string? (get-in history [0 :commit-id])) "Should have commit ID")
+        (is (instance? java.util.Date (get-in history [0 :commit-time])) "Should have commit time")
+        (is (string? (get-in history [0 :committer-name])) "Should have committer name")
+        (is (string? (get-in history [0 :commit-message])) "Should have commit message"))
+
+      (protocol/close storage))))
+
+(deftest test-document-at-commit
+  (testing "Get document at specific commit"
+    (let [storage (git/create-git-storage test-repo-path)
+          doc-v1 {:id "commit-test:1" :name "Original" :value 1 :_table "commit"}
+          doc-v2 {:id "commit-test:1" :name "Updated" :value 2 :_table "commit"}]
+
+      ;; Create document with multiple versions
+      (protocol/save-document storage doc-v1)
+      (protocol/save-document storage doc-v2)
+
+      ;; Get document history to find commit hash
+      (let [history (protocol/get-document-history storage "commit-test:1")
+            first-commit-hash (get-in history [1 :commit-id]) ;; Original version commit
+            repository (:repository storage)]
+
+        ;; Print commit hash for debugging
+        (println "Commit hash:" first-commit-hash)
+
+        ;; Get document at specific commit
+        (let [doc-at-commit (git/get-document-at-commit repository "commit-test:1" first-commit-hash)]
+          (is (= 1 (:value doc-at-commit)) "Should retrieve original version")
+          (is (= "Original" (:name doc-at-commit)) "Should have original name")))
+
+      (protocol/close storage))))
+
+(deftest test-restore-document-version
+  (testing "Restore document to previous version"
+    (let [storage (git/create-git-storage test-repo-path)
+          doc-v1 {:id "restore-test:1" :name "Original" :value 1 :_table "restore"}
+          doc-v2 {:id "restore-test:1" :name "Updated" :value 2 :_table "restore"}]
+
+      ;; Create document with multiple versions
+      (protocol/save-document storage doc-v1)
+      (protocol/save-document storage doc-v2)
+
+      ;; Current version should be v2
+      (is (= 2 (:value (protocol/get-document storage "restore-test:1"))))
+
+      ;; Get document history to find commit hash
+      (let [history (protocol/get-document-history storage "restore-test:1")
+            original-commit-hash (get-in history [1 :commit-id])] ;; Original version commit
+
+        ;; Restore document to original version
+        (let [restored-doc (git/restore-document-version storage "restore-test:1" original-commit-hash)]
+          (is (= 1 (:value restored-doc)) "Restored document should have original value")
+
+          ;; Verify current document is restored version
+          (let [current-doc (protocol/get-document storage "restore-test:1")]
+            (is (= 1 (:value current-doc)) "Current document should have original value")
+
+            ;; Check history again - should have 3 versions now (original, update, restore)
+            (let [new-history (protocol/get-document-history storage "restore-test:1")]
+              (is (= 3 (count new-history)) "Should have 3 versions in history now")
+              (is (= 1 (get-in new-history [0 :document :value])) "Most recent should be restored version")
+              (is (.contains (get-in new-history [0 :commit-message]) "Restore")
+                  "Commit message should indicate restoration")))))
+
+      (protocol/close storage))))
+
+(deftest test-restore-document-version-errors
+  (testing "Error handling when restoring document versions"
+    (let [storage (git/create-git-storage test-repo-path)
+          doc {:id "error-test:1" :name "Test" :value 1 :_table "error"}]
+
+      ;; Create document
+      (protocol/save-document storage doc)
+
+      ;; Try to restore with invalid commit hash
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Document version not found"
+                            (git/restore-document-version storage "error-test:1" "invalid-hash")))
+
+      ;; Try to restore non-existent document
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Document version not found"
+                            (git/restore-document-version storage "non-existent:1" "any-hash")))
+
+      (protocol/close storage))))
+
+(deftest test-document-version-rollback-history
+  (testing "Document rollback maintains complete history"
+    (let [storage (git/create-git-storage test-repo-path)
+          doc-v1 {:id "abc" :value 123 :_table "kv"}
+          doc-v2 {:id "abc" :value 1234 :_table "kv"}]
+
+      ;; 1. Create key "abc" with value 123
+      (protocol/save-document storage doc-v1)
+      (is (= 123 (:value (protocol/get-document storage "abc"))))
+
+      ;; 2. Edit key "abc" with value 1234
+      (protocol/save-document storage doc-v2)
+      (is (= 1234 (:value (protocol/get-document storage "abc"))))
+
+      ;; Verify we have 2 commits so far
+      (let [history-before (protocol/get-document-history storage "abc")]
+        (is (= 2 (count history-before)) "Should have 2 versions before rollback")
+
+        ;; Get the initial commit hash
+        (let [initial-commit-hash (get-in history-before [1 :commit-id])]
+          (println "Initial commit hash:" initial-commit-hash)
+
+          ;; 3. Rollback to the original version (value 123)
+          (let [restored-doc (git/restore-document-version storage "abc" initial-commit-hash)]
+            (is (= 123 (:value restored-doc)) "Should restore original value")
+
+            ;; Verify the current value after rollback
+            (is (= 123 (:value (protocol/get-document storage "abc"))) "Current value should be the original one")
+
+            ;; 4. Verify the history contains 3 commits
+            (let [history-after (protocol/get-document-history storage "abc")]
+              (is (= 3 (count history-after)) "Should have 3 versions in history")
+
+              ;; Verify the chronology of commits (most recent first)
+              (is (= 123 (get-in history-after [0 :document :value])) "Most recent commit should be the rollback (123)")
+              (is (= 1234 (get-in history-after [1 :document :value])) "Second commit should be the edit (1234)")
+              (is (= 123 (get-in history-after [2 :document :value])) "Third commit should be the original (123)")
+
+              ;; Verify the commit messages
+              (is (.contains (get-in history-after [0 :commit-message]) "Restore")
+                  "Commit message should indicate restoration")
+              (is (.contains (get-in history-after [1 :commit-message]) "Save")
+                  "Second commit should be a save operation")
+              (is (.contains (get-in history-after [2 :commit-message]) "Save")
+                  "Initial commit should be a save operation")))))
+
+      (protocol/close storage))))


### PR DESCRIPTION
Add low-level Git-based document history access to ChronDB, providing detailed commit metadata and document content at each version. This enhancement allows users to:

- Retrieve complete document history with Git commit information
- Access commit metadata including timestamps, authors, and messages
- View document content at each historical version
- Maintain full audit trail of document changes

The implementation includes:
- New `get-document-history` function in the storage protocol
- Git-specific implementation for detailed history retrieval
- Comprehensive test coverage for history operations
- Updated documentation with examples and usage patterns

This change enables better audit capabilities and deeper integration with Git's version control features.

fixed: #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded documentation for version control features, including detailed instructions and examples for accessing document history, retrieving document states at specific commits, and restoring documents to previous versions while preserving history.
- **New Features**
  - Added the ability to view detailed document version history, including commit metadata.
  - Enabled retrieval of a document’s state at any specific commit.
  - Introduced restoration of documents to previous versions with full audit trail preservation.
- **Tests**
  - Added comprehensive tests covering version history retrieval, commit-based document access, restoration, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->