### PR TITLE
feat: change license from MIT to GPLv3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,17 @@
-MIT License
+ChronDB is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-Copyright (c) 2025 moclojer
+ChronDB is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+---
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Full license text:
+<https://www.gnu.org/licenses/gpl-3.0.txt>

--- a/README.md
+++ b/README.md
@@ -262,4 +262,10 @@ Please make sure to update tests as appropriate.
 
 ## License
 
-This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) file for details.
+ChronDB is licensed under the terms of the GNU General Public License v3.0 (GPLv3).
+
+This means:
+
+- You are free to use, study, modify, and redistribute the software.
+- Any distributed modified version must also be licensed under GPLv3.
+- See the [LICENSE](./LICENSE) file for full details or visit [gnu.org/licenses/gpl-3.0](https://www.gnu.org/licenses/gpl-3.0.html).

--- a/src/chrondb/core.clj
+++ b/src/chrondb/core.clj
@@ -1,3 +1,17 @@
+;; This file is part of ChronDB.
+;;
+;; ChronDB is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; ChronDB is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see <https://www.gnu.org/licenses/>.
 (ns chrondb.core
   "Core namespace for ChronDB - A chronological database with Git-like versioning"
   (:require [chrondb.api.server :as server]

--- a/src/chrondb/storage/git.clj
+++ b/src/chrondb/storage/git.clj
@@ -1,3 +1,17 @@
+;; This file is part of ChronDB.
+;;
+;; ChronDB is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; ChronDB is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see <https://www.gnu.org/licenses/>.
 (ns chrondb.storage.git
   "Git-based storage implementation for ChronDB.
    Uses JGit for Git operations and provides versioned document storage."
@@ -368,7 +382,7 @@
                       content (String. (.getBytes object-loader) "UTF-8")
                       doc (json/read-str content :key-fn keyword)]
                   (if (or (empty? encoded-prefix)
-                           ;; If we have a prefix, check if the path contains it
+                          ;; If we have a prefix, check if the path contains it
                           (.contains path encoded-prefix))
                     (do
                       (log/log-info (str "Document matched prefix: " (:id doc)))


### PR DESCRIPTION
This commit changes the project's license from MIT to GNU General Public License v3.0 (GPLv3). This change:

- Provides stronger copyleft protection
- Ensures modifications remain open source
- Aligns with the project's goals of maintaining open access to all versions
- Updates documentation to reflect the new license terms

The change affects:
- LICENSE file with new GPLv3 text
- README.md with updated license section
- Core files with updated license headers
- Git storage implementation with updated headers

This is a significant change that affects how the software can be used and distributed. Users should review the new license terms carefully.

fixed: #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project license from MIT to GNU General Public License v3.0 (GPLv3) in the LICENSE file and README.
  - Added GPLv3 license headers to relevant source files.
  - Clarified user rights and obligations under GPLv3 in the README.
  - Made minor improvements to comment formatting in source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->